### PR TITLE
Eng 1266 fix cyrillic product titles rendering as mojibake in tolstoy

### DIFF
--- a/lib/modules/api/services/api.dart
+++ b/lib/modules/api/services/api.dart
@@ -52,7 +52,7 @@ class ApiService {
         const cast = Cast(location: "ApiService.getTvPageConfigsByAppKey");
 
         final jsonData =
-            cast.jsonMapOrNull(json.decode(response.body), "response.body");
+            cast.jsonMapOrNull(json.decode(utf8.decode(response.bodyBytes)), "response.body");
 
         if (jsonData == null) {
           const message = "Failed to load TV page configs by app key";
@@ -143,7 +143,7 @@ class ApiService {
         const cast = Cast(location: "ApiService.getTvPageConfig");
 
         final jsonData =
-            cast.jsonMapOrNull(json.decode(response.body), "response.body");
+            cast.jsonMapOrNull(json.decode(utf8.decode(response.bodyBytes)), "response.body");
 
         if (jsonData == null) {
           const message = "Failed to load TV page config";
@@ -206,7 +206,7 @@ class ApiService {
         const cast = Cast(location: "ApiService.getProductsByVodAssetIds");
 
         final jsonData =
-            cast.jsonMapOrNull(json.decode(response.body), "response.body");
+            cast.jsonMapOrNull(json.decode(utf8.decode(response.bodyBytes)), "response.body");
 
         if (jsonData == null) {
           const message = "Failed to load products by VOD asset IDs";
@@ -313,7 +313,7 @@ class ApiService {
     if (response.statusCode == 200) {
       const cast = Cast(location: "ApiService.getCacheVersion");
 
-      final jsonData = cast.jsonMap(json.decode(response.body), "body");
+      final jsonData = cast.jsonMap(json.decode(utf8.decode(response.bodyBytes)), "body");
 
       cacheVersion = cast.string(jsonData["cacheVersion"], "body.cacheVersion");
     } else {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: tolstoy_flutter_sdk
 description: "Tolstoy Flutter SDK"
 publish_to: 'none'
-version: 0.1.19
+version: 0.1.20
 
 environment:
   sdk: ^3.3.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes only how HTTP response bodies are decoded before JSON parsing, plus a patch version bump; behavior should remain the same for valid JSON but could surface encoding-related backend issues.
> 
> **Overview**
> Fixes mojibake for non-ASCII (e.g., Cyrillic) text by decoding API responses from `response.bodyBytes` as UTF-8 before `json.decode` in `ApiService` endpoints that load TV configs, products, and cache version.
> 
> Bumps the package version from `0.1.19` to `0.1.20`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b025835b503f0000cf07d9161e04d08c623df8f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->