### PR TITLE
feat: shuffle random-order TV feed client-side per launch

### DIFF
--- a/lib/modules/api/models/tv_page_config.dart
+++ b/lib/modules/api/models/tv_page_config.dart
@@ -19,6 +19,8 @@ class TvPageConfig {
     required this.createProductsLoader,
     this.onError,
     this.userId,
+    this.mediaSortOrder,
+    this.pinnedStepIds = const [],
   }) : productsLoader = createProductsLoader(
           appKey: appKey,
           appUrl: appUrl,
@@ -57,6 +59,9 @@ class TvPageConfig {
       appKey: parse.string("appKey"),
       owner: parse.string("owner"),
       userId: parse.stringOrNull("userId"),
+      mediaSortOrder: parse.stringOrNull("mediaSortOrder"),
+      pinnedStepIds:
+          parse.listOrNull("pinnedStepIds", (id) => cast.string(id, "pinnedStepIds::id")) ?? const [],
       createProductsLoader: createProductsLoader,
       onError: onError,
     );
@@ -73,6 +78,10 @@ class TvPageConfig {
   final ProductsLoaderFactory createProductsLoader;
   final SdkErrorCallback? onError;
   final String? userId;
+  // 'random' feeds are shuffled client-side per device/launch (the cached config is shared across
+  // devices, so the server can't randomize without breaking the CDN cache). pinnedStepIds keep their slots.
+  final String? mediaSortOrder;
+  final List<String> pinnedStepIds;
   final ProductsLoader productsLoader;
 
   TvPageConfig copyWith({
@@ -85,6 +94,8 @@ class TvPageConfig {
     String? appKey,
     String? owner,
     String? userId,
+    String? mediaSortOrder,
+    List<String>? pinnedStepIds,
     ProductsLoaderFactory? createProductsLoader,
     SdkErrorCallback? onError,
   }) =>
@@ -98,6 +109,8 @@ class TvPageConfig {
         appKey: appKey ?? this.appKey,
         owner: owner ?? this.owner,
         userId: userId ?? this.userId,
+        mediaSortOrder: mediaSortOrder ?? this.mediaSortOrder,
+        pinnedStepIds: pinnedStepIds ?? this.pinnedStepIds,
         createProductsLoader: createProductsLoader ?? this.createProductsLoader,
         onError: onError ?? this.onError,
       );

--- a/lib/modules/api/services/api.dart
+++ b/lib/modules/api/services/api.dart
@@ -5,6 +5,7 @@ import "package:shared_preferences/shared_preferences.dart";
 import "package:tolstoy_flutter_sdk/core/config.dart";
 import "package:tolstoy_flutter_sdk/core/types.dart";
 import "package:tolstoy_flutter_sdk/modules/api/models.dart";
+import "package:tolstoy_flutter_sdk/modules/api/services/random_order.dart";
 import "package:tolstoy_flutter_sdk/modules/products/loaders/products_loader.dart";
 import "package:tolstoy_flutter_sdk/modules/products/models.dart";
 import "package:tolstoy_flutter_sdk/utils/benchmarked_future.dart";
@@ -152,11 +153,24 @@ class ApiService {
           return null;
         }
 
-        return TvPageConfig.fromJson(
+        final config = TvPageConfig.fromJson(
           jsonData,
           createProductsLoader,
           onError: onError,
         );
+
+        // The config response is shared (CDN-cached), so randomize "random order" feeds here.
+        if (config.mediaSortOrder == "random") {
+          return config.copyWith(
+            assets: shuffleAssetsWithSeed(
+              config.assets,
+              config.pinnedStepIds,
+              tvFeedShuffleSeed,
+            ),
+          );
+        }
+
+        return config;
       } else {
         const message = "Failed to load TV page config";
         debugError(message);

--- a/lib/modules/api/services/random_order.dart
+++ b/lib/modules/api/services/random_order.dart
@@ -1,0 +1,38 @@
+import "dart:math";
+
+import "package:tolstoy_flutter_sdk/modules/assets/models.dart";
+import "package:uuid/uuid.dart";
+
+/// A seed generated once per app launch, so a "random order" feed keeps a stable order within a
+/// session but differs across devices and restarts.
+final String tvFeedShuffleSeed = const Uuid().v4();
+
+/// Shuffles a "random order" feed client-side, mirroring the storefront web randomizer.
+///
+/// The feed config is served from a shared CDN cache (identical bytes for every device), so the
+/// order is randomized here rather than on the server. Seeding by a per-launch value keeps the
+/// order stable within a session while differing across devices and app restarts.
+/// Pinned steps keep their original positions; only the rest are shuffled into the gaps.
+List<Asset> shuffleAssetsWithSeed(
+  List<Asset> assets,
+  List<String> pinnedStepIds,
+  String seed,
+) {
+  if (assets.length <= 1) {
+    return assets;
+  }
+
+  final pinned = pinnedStepIds.toSet();
+  final movable = assets.where((asset) => !pinned.contains(asset.id)).toList();
+
+  if (movable.length <= 1) {
+    return assets;
+  }
+
+  movable.shuffle(Random(seed.hashCode));
+
+  var next = 0;
+  return assets
+      .map((asset) => pinned.contains(asset.id) ? asset : movable[next++])
+      .toList();
+}


### PR DESCRIPTION
## Summary

A Tapcart "For You Feed" set to **Random order** showed the same video sequence on every device. The feed config is fetched from a shared CDN cache (`cf-apilb`/Fastly, keyed by publishId+cacheVersion), so the server can't randomize it without freezing one order across all devices. Fix: randomize **client-side**, the same pattern the storefront web player uses.

## Changes

- `TvPageConfig` now parses `mediaSortOrder` + `pinnedStepIds` (newly exposed by the backend).
- When `mediaSortOrder == 'random'`, shuffle the feed assets in `getTvPageConfig` via `shuffleAssetsWithSeed` — pin-preserving, seeded once per app launch (`tvFeedShuffleSeed`). Stable within a session, **different across devices and app restarts**.

## Requires

Backend PR exposing `mediaSortOrder`/`pinnedStepIds` on `getMobileSettings` (tolstoy-backend-cdk #14716). Until that ships, `mediaSortOrder` is absent → no shuffle (safe no-op).

## Verification

- `dart analyze lib/modules/api` → no issues.
- Shuffle algorithm is a port of the storefront web randomizer (Fisher-Yates, pin-preserving), already verified on real feed data: same seed → stable, different seed → different order, pins held, no media lost.