### PR TITLE
chore: bump version to 0.1.21

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: tolstoy_flutter_sdk
 description: "Tolstoy Flutter SDK"
 publish_to: 'none'
-version: 0.1.20
+version: 0.1.21
 
 environment:
   sdk: ^3.3.0


### PR DESCRIPTION
## What
Bump `pubspec` version `0.1.20` → `0.1.21`.

## Why
The client-side random-order feed shuffle (#36) merged to master **after** the `v0.1.20` tag (`v0.1.20` points to `69f3cab`, before the shuffle). No released tag currently contains the shuffle.

This bump releases it. **After merge, tag the merge commit `v0.1.21`** so consumers (e.g. `tolstoy-flutter-dev`, which pins by tag) can pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)